### PR TITLE
Fixed concurrency issue with params.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var Readable = require('stream').Readable;
 var util = require('util');
 var debug = require('debug')('s3-download-stream');
 var SimpleQueue = require('SimpleQueue');
+var clone = require('clone');
 util.inherits(S3Readable, Readable);
 
 module.exports = S3Readable;
@@ -54,8 +55,9 @@ S3Readable.prototype._read = function(numBytes) {
 
 S3Readable.prototype.sip = function(from, numBytes, done) {
   var self = this;
-  var rng = this.params.Range = range(from, numBytes)
-  var req = self.client.getObject(self.params, function(err, res){
+  var params = clone(this.params)
+  var rng = params.Range = range(from, numBytes)
+  var req = self.client.getObject(params, function(err, res){
     // range is past EOF, can return safely
     if (err && err.statusCode === 416) return done(null, { data: null })
     if (err) return done(err)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "SimpleQueue": "0.0.1",
+    "clone": "^1.0.2",
     "debug": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We discovered an issue which occurs sporadically when `opts.concurrency` > 1.
The behaviour we observed is that an empty buffer is returned when reading the stream, because the same `params` object is reused concurrently in the `sip` method.  You can see the effect of this if you log the bytes that are attempting to be read - when the error occurs, these byte ranges are incorrect.

Cloning `params` resolves the issue.

/cc @mcollina